### PR TITLE
Create `StaticMDCBinder` using `BasicMDCAdapter` as implementation

### DIFF
--- a/odin-slf4j-bridge/src/main/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/odin-slf4j-bridge/src/main/java/org/slf4j/impl/StaticMDCBinder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Permutive
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.slf4j.impl;
+
+import org.slf4j.spi.MDCAdapter;
+import org.slf4j.helpers.BasicMDCAdapter;
+
+public class StaticMDCBinder {
+
+    public static final StaticMDCBinder SINGLETON = new StaticMDCBinder();
+
+    private StaticMDCBinder() {
+    }
+
+    public static StaticMDCBinder getSingleton() {
+        return SINGLETON;
+    }
+
+    public MDCAdapter getMDCA() {
+        return new BasicMDCAdapter();
+    }
+
+    public String getMDCAdapterClassStr() {
+        return BasicMDCAdapter.class.getName();
+    }
+
+}


### PR DESCRIPTION
This allows projects using this library to avoid the following error (and basically having no implementation of `MDCAdapter`:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
SLF4J: Defaulting to no-operation MDCAdapter implementation.s
SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
```